### PR TITLE
Week one

### DIFF
--- a/opensearch/bbuy_products.json
+++ b/opensearch/bbuy_products.json
@@ -1,5 +1,284 @@
 {
   "settings": {
     "index.refresh_interval": "5s"
+  },
+  "mappings": {
+    "properties": {
+      "accessories": {
+        "type": "keyword"
+      },
+      "active": {
+        "type": "boolean"
+      },
+      "artistName": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "bestBuyItemId": {
+        "type": "keyword"
+      },
+      "bestSellingRank": {
+        "type": "integer"
+      },
+      "categoryLeaf": {
+        "type": "keyword"
+      },
+      "categoryPath": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "categoryPathCount": {
+        "type": "integer"
+      },
+      "categoryPathIds": {
+        "type": "keyword"
+      },
+      "class": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "classId": {
+        "type": "keyword"
+      },
+      "color": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "condition": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "customerReviewAverage": {
+        "type": "float"
+      },
+      "customerReviewCount": {
+        "type": "integer"
+      },
+      "department": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "departmentId": {
+        "type": "keyword"
+      },
+      "depth": {
+        "type": "keyword"
+      },
+      "description": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "digital": {
+        "type": "boolean"
+      },
+      "features": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "frequentlyPurchasedWith": {
+        "type": "keyword"
+      },
+      "height": {
+        "type": "keyword"
+      },
+      "homeDelivery": {
+        "type": "boolean"
+      },
+      "image": {
+        "type": "keyword"
+      },
+      "inStoreAvailability": {
+        "type": "boolean"
+      },
+      "inStorePickup": {
+        "type": "boolean"
+      },
+      "longDescription": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "longDescriptionHtml": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "manufacturer": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "modelNumber": {
+        "type": "keyword"
+      },
+      "name": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "onSale": {
+        "type": "boolean"
+      },
+      "onlineAvailability": {
+        "type": "boolean"
+      },
+      "productId": {
+        "type": "keyword"
+      },
+      "quantityLimit": {
+        "type": "integer"
+      },
+      "regularPrice": {
+        "type": "float"
+      },
+      "relatedProducts": {
+        "type": "keyword"
+      },
+      "releaseDate": {
+        "type": "date"
+      },
+      "salePrice": {
+        "type": "float"
+      },
+      "salesRankLongTerm": {
+        "type": "integer"
+      },
+      "salesRankMediumTerm": {
+        "type": "integer"
+      },
+      "salesRankShortTerm": {
+        "type": "integer"
+      },
+      "shippingCost": {
+        "type": "float"
+      },
+      "shippingWeight": {
+        "type": "float"
+      },
+      "shortDescription": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "shortDescriptionHtml": {
+        "type": "text",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "sku": {
+        "type": "keyword"
+      },
+      "startDate": {
+        "type": "date"
+      },
+      "subclass": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "subclassId": {
+        "type": "keyword"
+      },
+      "type": {
+        "type": "text",
+        "analyzer": "english",
+        "fields": {
+          "keyword": {
+            "type": "keyword",
+            "ignore_above": 256
+          }
+        }
+      },
+      "url": {
+        "type": "keyword"
+      },
+      "weight": {
+        "type": "keyword"
+      },
+      "width": {
+        "type": "keyword"
+      }
+    }
   }
 }

--- a/opensearch/bbuy_products.json
+++ b/opensearch/bbuy_products.json
@@ -196,7 +196,8 @@
         "type": "integer"
       },
       "regularPrice": {
-        "type": "float"
+        "type": "scaled_float",
+        "scaling_factor": 100
       },
       "relatedProducts": {
         "type": "keyword"
@@ -205,7 +206,8 @@
         "type": "date"
       },
       "salePrice": {
-        "type": "float"
+        "type": "scaled_float",
+        "scaling_factor": 100
       },
       "salesRankLongTerm": {
         "type": "integer"

--- a/week1/index_products.py
+++ b/week1/index_products.py
@@ -85,7 +85,18 @@ def get_opensearch():
     port = 9200
     auth = ('admin', 'admin')
     #### Step 2.a: Create a connection to OpenSearch
-    client = None
+    client = OpenSearch(
+        hosts=[{'host': host, 'port': port}],
+        http_compress=True,  # enables gzip compression for request bodies
+        http_auth=auth,
+        # client_cert = client_cert_path,
+        # client_key = client_key_path,
+        use_ssl=True,
+        verify_certs=False,
+        ssl_assert_hostname=False,
+        ssl_show_warn=False,
+        #ca_certs=ca_certs_path
+    )
     return client
 
 
@@ -107,8 +118,15 @@ def index_file(file, index_name):
         if 'productId' not in doc or len(doc['productId']) == 0:
             continue
         #### Step 2.b: Create a valid OpenSearch Doc and bulk index 2000 docs at a time
-        the_doc = None
+        the_doc = { '_index': index_name, '_source': doc }
         docs.append(the_doc)
+
+        if len(docs) > 2000:
+            bulk(client, docs, request_timeout=60)
+            docs = []
+    
+    if docs:
+        bulk(client, docs, request_timeout=60)
 
     return docs_indexed
 

--- a/week1/opensearch.py
+++ b/week1/opensearch.py
@@ -6,6 +6,17 @@ def get_opensearch():
     if 'opensearch' not in g:
         #### Step 4.a:
         # Implement a client connection to OpenSearch so that the rest of the application can communicate with OpenSearch
-        g.opensearch = None
+        g.opensearch = OpenSearch(
+            hosts=[{'host': 'localhost', 'port': '9200'}],
+            http_compress=True,  # enables gzip compression for request bodies
+            http_auth=('admin', 'admin'),
+            # client_cert = client_cert_path,
+            # client_key = client_key_path,
+            use_ssl=True,
+            verify_certs=False,
+            ssl_assert_hostname=False,
+            ssl_show_warn=False,
+            #ca_certs=ca_certs_path
+        )
 
     return g.opensearch

--- a/week1/search.py
+++ b/week1/search.py
@@ -30,11 +30,11 @@ def process_filters(filters_input):
             print("from: {}, to: {}".format(from_val, to_val))
             # we need to turn the "to-from" syntax of aggregations to the "gte,lte" syntax of range filters.
             to_from = {}
-            if from_val:
+            if from_val and from_val != "*":
                 to_from["gte"] = from_val
             else:
                 from_val = "*"  # set it to * for display purposes, but don't use it in the query
-            if to_val:
+            if to_val and to_val != "*":
                 to_from["lt"] = to_val
             else:
                 to_val = "*"  # set it to * for display purposes, but don't use it in the query

--- a/week1/search.py
+++ b/week1/search.py
@@ -94,7 +94,7 @@ def query():
     print("query obj: {}".format(query_obj))
 
     #### Step 4.b.ii
-    response = None   # TODO: Replace me with an appropriate call to OpenSearch
+    response = opensearch.search(body=query_obj, index="bbuy_products")
     # Postprocess results here if you so desire
 
     #print(response)
@@ -111,11 +111,113 @@ def create_query(user_query, filters, sort="_score", sortDir="desc"):
     query_obj = {
         'size': 10,
         "query": {
-            "match_all": {} # Replace me with a query that both searches and filters
+            "function_score": {
+                "query": {
+                    "boosting": {
+                        "positive": {
+                            "bool": {
+                                "must": {
+                                    "query_string": {
+                                        "fields": ["name^100", "shortDescription^50", "longDescription^10", "department"],
+                                        "phrase_slop": 3,
+                                        "query": user_query
+                                    }
+                                },
+                                "filter": filters,
+                            }
+                        },
+                        "negative": {
+                            "multi_match": {
+                                "fields": ["longDescription", "shortDescription", "name"], 
+                                "query": "your compatible"
+                            }
+                        },
+                        "negative_boost": 0.2
+                    },
+                },
+                "boost_mode": "multiply",
+                "score_mode": "avg",
+                "functions": [
+                    {
+                        "field_value_factor": {
+                            "field": "salesRankLongTerm",
+                            "modifier": "reciprocal",
+                            "missing": 100000000
+                        }
+                    },
+                    {
+                        "field_value_factor": {
+                            "field": "salesRankMediumTerm",
+                            "modifier": "reciprocal",
+                            "missing": 100000000
+                        }
+                    },
+                    {
+                        "field_value_factor": {
+                            "field": "salesRankShortTerm",
+                            "modifier": "reciprocal",
+                            "missing": 100000000
+                        }
+                    }
+                ]
+            }
         },
         "aggs": {
-            #### Step 4.b.i: create the appropriate query and aggregations here
-
-        }
+            "department": {
+                "terms": {
+                    "field": "department.keyword"
+                }
+            },
+            "regularPrice": {
+                "range": {
+                    "field": "regularPrice",
+                    "ranges": [
+                        {
+                            "key": "$",
+                            "to": 100
+                        },
+                        {
+                            "key": "$$",
+                            "from": 100,
+                            "to": 200
+                        },
+                        {
+                            "key": "$$$",
+                            "from": 200,
+                            "to": 300
+                        },
+                        {
+                            "key": "$$$$",
+                            "from": 300,
+                            "to": 400
+                        },
+                        {
+                            "key": "$$$$$",
+                            "from": 400,
+                            "to": 500,
+                        },
+                        {
+                            "key": "$$$$$$",
+                            "from": 500,
+                        }
+                    ]
+                }
+            },
+            "missing_images": {
+                "missing": {
+                    "field": "image"
+                }
+            }
+        },
+        "highlight": {
+            "fields": {
+                "name": { "pre_tags" : ["<b>"], "post_tags" : ["</b>"] },
+                "shortDescription": { "pre_tags" : ["<b>"], "post_tags" : ["</b>"] },
+                "longDescription": { "pre_tags" : ["<b>"], "post_tags" : ["</b>"] },
+            }
+        },
+        "sort": [
+            { sort: { "order": sortDir} }
+        ]
     }
     return query_obj


### PR DESCRIPTION
## Wanted Mappings
- I used "text" type with the "english" analyzer, because the text is in English and stemming is covered. One thing I noticed that could be problematic is that the English analyzer contains stopwords like "for" and "with", and these are the terms I was trying to negatively boost in vain 😅 Maybe it could have made sense to only use stemmer (e.g. Porter stemmer) and not remove the stopwords for the name in particular? 🤔
- Since the prices aren't used for monetary transactions in this use case, and usually round up to two digits, I used "scaled_float" with a factor of 100. It also saves some disk space and speeds the things a tiny bit, according to Elastic docs.

## More Mappings
- Things like "color", "condition", "manufacturer", "artistName", etc. are also potentially searchable, so I added "english" analyzer there as well. Most of them consist of a single word, but we lowercasing and stemming for free.
- IDs, SKUs, freeform widths, weights and heights are all keywords

## iPad 2 and differences to the docs
- In comparison to the instructions I did keep the "boosting" query, though.